### PR TITLE
Adjust for use on Linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
     image: ghcr.io/ust-quantil/qhana-backend:main
     volumes:
       - experiments:/app/data
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - 9090:9090
   ui:


### PR DESCRIPTION
To get it to work on Linux, the host `host.docker.internal` must be defined explicitly to point to the host.
Otherwise the address `host.docker.internal:5005` for the plugin runner can't be resolved by the backend.
You can read about it [here](https://medium.com/@TimvanBaarsen/how-to-connect-to-the-docker-host-from-inside-a-docker-container-112b4c71bc66).

Another hint for others trying to run it on Linux:
It does not work if you use `ufw` as your firewall.
You need to install and use `firewalld` and disable `ufw`.