### PR TITLE
Add URL mapping options and minio storage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     depends_on:
       - redis
       - postgres
+      - minio
     ports:
       - "5005:8080"
     volumes:
@@ -14,6 +15,9 @@ services:
       BROKER_URL: redis://redis:6379
       RESULT_BACKEND: redis://redis:6379
       SQLALCHEMY_DATABASE_URI: "postgresql+psycopg2://user:password@postgres:5432/default_db"
+      DEFAULT_FILE_STORE: "minio"
+      MINIO_CLIENT: '{"endpoint": "minio:9000", "access_key": "QHANA", "secret_key": "QHANAQHANA", "secure": false}'
+      URL_MAP: '{"(https?://)(localhost|host.docker.internal):9090": "\\1backend:9090"}'
       GIT_PLUGINS: "git+https://github.com/UST-QuAntiL/qhana-plugin-runner.git@main#subdirectory=/plugins"
   redis:
     image: "redis:latest"
@@ -25,6 +29,17 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_USER: user
       POSTGRES_DB: default_db
+  minio:
+    image: quay.io/minio/minio 
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio:/data
+    environment: 
+      MINIO_ROOT_USER: QHANA
+      MINIO_ROOT_PASSWORD: QHANAQHANA
+    ports:
+      - "9000:9000"
+      - "9001:9001"
   muse-db:
     image: "muse-db"
     profiles:
@@ -42,6 +57,9 @@ services:
       BROKER_URL: redis://redis:6379
       RESULT_BACKEND: redis://redis:6379
       SQLALCHEMY_DATABASE_URI: "postgresql+psycopg2://user:password@postgres:5432/default_db"
+      DEFAULT_FILE_STORE: "minio"
+      MINIO_CLIENT: '{"endpoint": "minio:9000", "access_key": "QHANA", "secret_key": "QHANAQHANA", "secure": false}'
+      URL_MAP: '{"(https?://)(localhost|host.docker.internal):9090": "\\1backend:9090"}'
       GIT_PLUGINS: "git+https://github.com/UST-QuAntiL/qhana-plugin-runner.git@main#subdirectory=/plugins"
   backend:
     image: ghcr.io/ust-quantil/qhana-backend:main
@@ -49,6 +67,8 @@ services:
       - experiments:/app/data
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    environment:
+      QHANA_URL_MAPPING: '{"(?<=^|https?://)(localhost|host.docker.internal):5005": "qhana-plugin-runner:8080", "(?<=^|https?://)localhost(:[0-9]+)?": "host.docker.internal$$1"}'
     ports:
       - 9090:9090
   ui:
@@ -56,5 +76,6 @@ services:
     ports:
       - 8080:8080
 volumes:
+  minio:
   instance:
   experiments:


### PR DESCRIPTION
Add URL mapping options to compose file to aviod requests to the docker host that could be blocked by a firewall.
Add minio config and container to store plugin runner results in.

Possible improvements:
- Expose postgres port to allow externally started plugin runners to use the infrastructure defined in this docker compose file
- Add persistance volumes for redis and postgres