### PR TITLE
Enable stable execution results prioritization

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,8 @@ services:
   nisq-analyzer-ui:
     profiles: ["nisq"]
     image: planqk/nisq-analyzer-ui:latest
+    depends_on:
+      - nisq-analyzer-db
     environment:
       NISQ_ANALYZER_HOST_NAME: localhost
       NISQ_ANALYZER_PORT: 5010
@@ -240,7 +242,9 @@ services:
       - default
 
   nisq-analyzer-db:
-    image: postgres
+    build:
+      context: nisq-analyzer-db
+      dockerfile: Dockerfile-nisq-analyzer-content
     profiles: ["nisq"]
     environment:
       POSTGRES_PASSWORD: nisq

--- a/nisq-analyzer-db/Dockerfile-nisq-analyzer-content
+++ b/nisq-analyzer-db/Dockerfile-nisq-analyzer-content
@@ -1,0 +1,8 @@
+FROM postgres
+
+# copy db dump (https://github.com/UST-QuAntiL/nisq-analyzer-content/raw/master/prioritization-based-on-learned-weights/sample-data/20220313_nisq.sql)
+COPY nisq.sql /docker-entrypoint-initdb.d/
+
+EXPOSE 5060
+
+CMD su postgres -c "/usr/local/bin/docker-entrypoint.sh postgres -p 5060"


### PR DESCRIPTION
To enable "stable execution results"-prioritization via the NISQ Analyzer plugin, the database (`nisq-analyzer-db`) needs corresponding data.

### Our Solution: 

A [minimal Dockerfile](https://github.com/UST-QuAntiL/qhana-docker/blob/nisq-result-prioritization/nisq-analyzer-db/Dockerfile-nisq-analyzer-content) to load a db dump. We used the data from [this dump](https://github.com/UST-QuAntiL/nisq-analyzer-content/blob/master/prioritization-based-on-learned-weights/sample-data/20220313_nisq.sql).
