### PR TITLE
Extend proxy config, prevent connection errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       SQLALCHEMY_DATABASE_URI: "postgresql+psycopg2://user:password@postgres:5432/default_db"
       DEFAULT_FILE_STORE: "minio"
       MINIO_CLIENT: '{"endpoint": "minio:9000", "access_key": "QHANA", "secret_key": "QHANAQHANA", "secure": false}'
-      LOCALHOST_PROXY_PORTS: ":9090"
+      LOCALHOST_PROXY_PORTS: ":9090 ${EXTRA_PROXY_PORTS}"
       GIT_PLUGINS: "git+https://github.com/UST-QuAntiL/qhana-plugin-runner.git@main#subdirectory=/plugins\ngit+https://github.com/UST-QuAntiL/nisq-analyzer-prio-service.git@master#subdirectory=/plugins"
       NISQ_ANALYZER_UI_URL: http://localhost:5009
     extra_hosts:
@@ -66,7 +66,7 @@ services:
       SQLALCHEMY_DATABASE_URI: "postgresql+psycopg2://user:password@postgres:5432/default_db"
       DEFAULT_FILE_STORE: "minio"
       MINIO_CLIENT: '{"endpoint": "minio:9000", "access_key": "QHANA", "secret_key": "QHANAQHANA", "secure": false}'
-      LOCALHOST_PROXY_PORTS: ":9090"
+      LOCALHOST_PROXY_PORTS: ":9090 ${EXTRA_PROXY_PORTS}"
       GIT_PLUGINS: "git+https://github.com/UST-QuAntiL/qhana-plugin-runner.git@main#subdirectory=/plugins\ngit+https://github.com/UST-QuAntiL/nisq-analyzer-prio-service.git@master#subdirectory=/plugins"
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -77,8 +77,8 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
-      LOCALHOST_PROXY_PORTS: ":5005"
-      QHANA_HOST: http://host.docker.internal:9090
+      LOCALHOST_PROXY_PORTS: ":5005 ${EXTRA_PROXY_PORTS}"
+      QHANA_HOST: http://localhost:9090
     ports:
       - 9090:9090
   ui:
@@ -119,7 +119,7 @@ services:
       RESULT_BACKEND: redis://redis:6379
       CELERY_QUEUE: "registry_queue"
       SQLALCHEMY_DATABASE_URI: "postgresql+psycopg2://user:password@postgres-registry:5432/default_db"
-      LOCALHOST_PROXY_PORTS: ":5005"
+      LOCALHOST_PROXY_PORTS: ":5005  ${EXTRA_PROXY_PORTS}"
       PLUGIN_DISCOVERY_INTERVAL: 60
       PERIODIC_SCHEDULER: true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,9 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
-      WAIT_HOSTS: redis:6379, postgres-registry:5432
+      WAIT_HOSTS: redis:6379, postgres-registry:5432, qhana-plugin-runner:8080
+      WAIT_SLEEP_INTERVAL: 5
+      WAIT_TIMEOUT: 600
       BROKER_URL: redis://redis:6379
       RESULT_BACKEND: redis://redis:6379
       CELERY_QUEUE: "registry_queue"
@@ -113,7 +115,9 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
-      WAIT_HOSTS: redis:6379, postgres-registry:5432
+      WAIT_HOSTS: redis:6379, postgres-registry:5432, qhana-plugin-runner:8080
+      WAIT_SLEEP_INTERVAL: 5
+      WAIT_TIMEOUT: 600
       CONTAINER_MODE: worker
       BROKER_URL: redis://redis:6379
       RESULT_BACKEND: redis://redis:6379

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,12 @@ If you want to use the [NISQ-Analyzer](https://github.com/UST-QuAntiL/nisq-analy
 Open http://localhost:8080 in a web browser to use the QHAna UI.
 
 
+## Proxy configuration
+
+To temporarily add more ports to the proxy configuration, set the environment variable `EXTRA_PROXY_PORTS` to the additional ports e.g. `:1234 :2345`.
+This can be done by creating a file named `.env` that contains `EXTRA_PROXY_PORTS=":1234 :2345"`.
+
+
 ## Build the Documentation
 
 ```bash

--- a/readme.md
+++ b/readme.md
@@ -7,9 +7,9 @@ The user documentation for QHAna can be viewed on [qhana.readthedocs.io](https:/
 
 ## Start
 
-`docker-compose up`
+`docker compose up`
 
-If you want to use the [NISQ-Analyzer](https://github.com/UST-QuAntiL/nisq-analyzer) plugin, use `docker-compose --profile nisq up`.
+If you want to use the [NISQ-Analyzer](https://github.com/UST-QuAntiL/nisq-analyzer) plugin, use `docker compose --profile nisq up`.
 
 ## Using QHAna
 


### PR DESCRIPTION
Features:
- additional ports can be specified for the proxies with a environment variable

Fixes:
- fixing connection errors in the registry worker container while the plugin runner is still installing dependencies
- replacing `docker-compose` command in readme, because it will lose support in June 2023