### PR TITLE
Fix missing registry URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       GIT_PLUGINS: &git-plugins "git+https://github.com/UST-QuAntiL/qhana-plugin-runner.git@main#subdirectory=/stable_plugins\ngit+https://github.com/UST-QuAntiL/nisq-analyzer-prio-service.git@master#subdirectory=/plugins"
       PLUGIN_FOLDERS: &plugin-folders ./git-plugins:./git-plugins/classical_ml/data_preparation:./git-plugins/classical_ml/scikit_ml:./git-plugins/data_synthesis:./git-plugins/demo:./git-plugins/file_utils:./git-plugins/infrastructure:./git-plugins/muse:./git-plugins/nisq_analyzer:./git-plugins/quantum_ml/max_cut:./git-plugins/quantum_ml/pennylane_qiskit_ml:./git-plugins/quantum_ml/qiskit_ml:./git-plugins/visualization/complex:./git-plugins/visualization/file_types:./git-plugins/workflow
       NISQ_ANALYZER_UI_URL: http://localhost:5009
+      PLUGIN_REGISTRY_URL: http://localhost:5006/api/
     extra_hosts:
       - "host.docker.internal:host-gateway"
   redis:
@@ -78,6 +79,7 @@ services:
       LOCALHOST_PROXY_PORTS: *localhost-proxy-ports
       GIT_PLUGINS: *git-plugins
       PLUGIN_FOLDERS: *plugin-folders
+      PLUGIN_REGISTRY_URL: http://localhost:5006/api/
     extra_hosts:
       - "host.docker.internal:host-gateway"
   backend:


### PR DESCRIPTION
The missing registry URL results in an error when loading the micro frontend of the workflow management plugin, because it searches the registry for the workflow-editor plugin. 